### PR TITLE
Null reference fixes and rich text support

### DIFF
--- a/src/Enterspeed.Source.Contentful.CP/Factories/ContentfulFieldFactory.cs
+++ b/src/Enterspeed.Source.Contentful.CP/Factories/ContentfulFieldFactory.cs
@@ -8,7 +8,11 @@ public class ContentfulFieldFactory : IContentfulFieldFactory
     public ContentfulField Create(dynamic field)
     {
         if (field.Value.GetType() == typeof(JObject))
+        {
+            if (!string.IsNullOrEmpty(field.Value["nodeType"]?.Value))
+                return new ContentfulDocumentField(field);
             return new ContentfulObjectField(field);
+        }
         
         if (field.Value.GetType() == typeof(JArray))
             return new ContentfulArrayField(field);

--- a/src/Enterspeed.Source.Contentful.CP/Factories/ContentfulFieldFactory.cs
+++ b/src/Enterspeed.Source.Contentful.CP/Factories/ContentfulFieldFactory.cs
@@ -9,14 +9,14 @@ public class ContentfulFieldFactory : IContentfulFieldFactory
     {
         if (field.Value.GetType() == typeof(JObject))
         {
-            if (!string.IsNullOrEmpty(field.Value["nodeType"]?.Value))
+            if (!string.IsNullOrEmpty(field.Value["nodeType"]?.Value) && field.Value["nodeType"]?.Value.Equals("document", System.StringComparison.InvariantCultureIgnoreCase))
                 return new ContentfulDocumentField(field);
             return new ContentfulObjectField(field);
         }
-        
+
         if (field.Value.GetType() == typeof(JArray))
             return new ContentfulArrayField(field);
-        
+
         return new ContentfulSimpleField(field);
     }
 }

--- a/src/Enterspeed.Source.Contentful.CP/Models/ContentfulDocumentField.cs
+++ b/src/Enterspeed.Source.Contentful.CP/Models/ContentfulDocumentField.cs
@@ -1,0 +1,21 @@
+﻿using Contentful.Core.Configuration;
+using Contentful.Core.Models;
+using Newtonsoft.Json;
+
+namespace Enterspeed.Source.Contentful.CP.Models;
+
+public class ContentfulDocumentField : ContentfulField
+{
+    public ContentfulDocumentField(dynamic field)
+    {
+        var serializerSettings = new JsonSerializerSettings();
+        serializerSettings.Converters.Add(new ContentJsonConverter());
+        var document = JsonConvert.DeserializeObject<Document>(field.Value.ToString(), serializerSettings);
+
+        Name = field.Name;
+        Type = typeof(string);
+
+        var htmlRenderer = new HtmlRenderer();
+        Value = htmlRenderer.ToHtml(document).GetAwaiter().GetResult();
+    }
+}

--- a/src/Enterspeed.Source.Contentful.CP/Services/FieldValueConverters/ObjectFieldValueConverter.cs
+++ b/src/Enterspeed.Source.Contentful.CP/Services/FieldValueConverters/ObjectFieldValueConverter.cs
@@ -21,13 +21,18 @@ public class ObjectFieldValueConverter : IEnterspeedFieldValueConverter
 
     public IEnterspeedProperty Convert(ContentfulField field, Locale locale)
     {
+        if (field == null || locale == null)
+            return null;
         var value = ((ContentfulObjectField)field).GetValue();
-        var properties = new Dictionary<string, IEnterspeedProperty>
-        {
-            ["id"] = new StringEnterspeedProperty("id", _entityIdentityService.GetId(value.SystemProperties.Id, locale)),
-            ["type"] = new StringEnterspeedProperty("type", value.SystemProperties.Type),
-            ["linkType"] = new StringEnterspeedProperty("linkType", value.SystemProperties.LinkType)
-        };
+        if (value == null)
+            return null;
+        var properties = new Dictionary<string, IEnterspeedProperty>();
+        if (value.SystemProperties?.Id != null)
+            properties.Add("id", new StringEnterspeedProperty("id", _entityIdentityService.GetId(value.SystemProperties.Id, locale)));
+        if (value.SystemProperties?.Type != null)
+            properties.Add("type", new StringEnterspeedProperty("type", value.SystemProperties.Type));
+        if (value.SystemProperties?.Type != null)
+            properties.Add("linkType", new StringEnterspeedProperty("linkType", value.SystemProperties.LinkType));
 
         return new ObjectEnterspeedProperty(field.Name, properties);
     }


### PR DESCRIPTION
Added null checks in ObjectFieldValueConverter to fix null reference errors.
Added ContentfulDocumentField as part of the ContentfulFieldFactory to support rich text fields.